### PR TITLE
Support Rubocop 0.51, drop JRuby 1.7 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.1
   DisplayCopNames: true
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
 
 Lint/EndAlignment:
   EnforcedStyleAlignWith: variable
@@ -17,6 +20,9 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Severity: warning
 
+Naming/FileName:
+  Enabled: false
+
 # Rationale: allow Weirich-style blocks
 Style/BlockDelimiters:
   Enabled: false
@@ -24,22 +30,7 @@ Style/Documentation:
   Enabled: false
 Style/Encoding:
   Enabled: false
-Style/FileName:
-  Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
-Style/MultilineOperationIndentation:
-  EnforcedStyle: indented
 Style/NumericPredicate:
   Enabled: false
-
-# Default in v0.48.1, but older versions are being used for older Ruby versions, so we set this explicitly here to have the same
-# settings on all Ruby versions.
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    default: ()
-    '%i': '[]'
-    '%I': '[]'
-    '%r': '{}'
-    '%w': '[]'
-    '%W': '[]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - jruby-9.0.5.0
   - jruby-9.1.13.0
   - jruby-head
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - jruby-1.7.27
   - jruby-9.0.5.0
   - jruby-9.1.13.0
   - jruby-head

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ end
 
 RuboCop::RakeTask.new
 
-task default: [:spec, :rubocop]
+task default: %i[spec rubocop]

--- a/sequel-jdbc-as400.gemspec
+++ b/sequel-jdbc-as400.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.author = 'Jeremy Evans and contributors'
   s.homepage = 'https://github.com/ecraft/sequel-jdbc-as400'
   s.license = 'MIT'
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 2.1'
   s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) } -
     %w[.travis.yml .rubocop.yml]
   s.require_path = 'lib'

--- a/sequel-jdbc-as400.gemspec
+++ b/sequel-jdbc-as400.gemspec
@@ -17,10 +17,11 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'jdbc-jt400', '~> 9.1'
   s.add_runtime_dependency 'sequel', '~> 5.0'
+
   s.add_development_dependency 'activemodel'
   s.add_development_dependency 'nokogiri'
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'tzinfo'
-  s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Newer versions of Rubocop only support Ruby 2.1+. We cannot use these versions with the gem, unless we change the TargetRubyVersion in our .rubocop.yml file.

The simplest approach for fixing this is to drop JRuby 1.7 support. It has reached EOL anyway, and we have little internal need for the gem with JRuby 1.7. Hence, I suggest we drop it; _if_ we ever need it, we can fork out from our latest release and take it from there and onwards.