### PR TITLE
as400: Require sequel/adapters/jdbc

### DIFF
--- a/lib/sequel/jdbc/as400.rb
+++ b/lib/sequel/jdbc/as400.rb
@@ -1,5 +1,8 @@
 # frozen-string-literal: true
 
+require 'sequel'
+require 'sequel/adapters/jdbc'
+
 require 'jdbc/jt400'
 Jdbc::JT400.load_driver
 


### PR DESCRIPTION
This is a requirement for the gem to work correctly. The user has to do this, or we have to do it. Maybe it's better if we do it always, just to be on the safe side?