### PR TITLE
.travis.yml: Use JRuby 9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - jruby-9.1.15.0
+  - jruby-9.2
   - jruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
9.1.15.0 has started failing on Travis.