### PR TITLE
Modify limit/offset method to handle Placeholders

### DIFF
--- a/lib/sequel/jdbc/as400.rb
+++ b/lib/sequel/jdbc/as400.rb
@@ -71,23 +71,18 @@ module Sequel
         Sequel::Deprecation.deprecate_constant(self, :ROWS_ONLY)
 
         # Modify the sql to limit the number of rows returned
-        def select_limit_sql(sql) # rubocop:disable MethodLength
-          o = @opts[:offset]
-          if o
+        def select_limit_sql(sql)
+          if (o = @opts[:offset])
             sql << ' OFFSET '
             literal_append(sql, o)
             sql << ' ROWS'
           end
-          l = @opts[:limit]
-          return unless l
 
-          if l == 1
-            sql << ' FETCH FIRST ROW ONLY'
-          elsif l > 1
-            sql << ' FETCH FIRST '
-            literal_append(sql, l)
-            sql << ' ROWS ONLY'
-          end
+          return unless (l = @opts[:limit])
+
+          sql << ' FETCH FIRST '
+          literal_append(sql, l)
+          sql << ' ROWS ONLY'
         end
 
         def supports_window_functions?

--- a/spec/integration/limit_spec.rb
+++ b/spec/integration/limit_spec.rb
@@ -31,8 +31,8 @@ describe 'a limit query', needs_live_db2_server: true do
   context 'when using a cached dataset' do
     it 'should return an array with the correct number of elements' do
       # Sequel starts caching dataset query placeholder arguments on 3rd use
-      3.times { Items.create(name: 'N') }
-      some_items = Items.where(name: 'N')
+      3.times { Item.create(name: 'N') }
+      some_items = Item.where(name: 'N')
       3.times { expect(some_items.first(2).size).to eq(2) }
     end
   end

--- a/spec/integration/limit_spec.rb
+++ b/spec/integration/limit_spec.rb
@@ -5,7 +5,7 @@ describe 'a limit query', needs_live_db2_server: true do
         primary_key :id
         String :name
       end
-      class ::Item < Sequel::Model(db)
+      class Item < Sequel::Model(db)
       end
     end
   end

--- a/spec/integration/limit_spec.rb
+++ b/spec/integration/limit_spec.rb
@@ -16,7 +16,7 @@ describe 'a limit query', needs_live_db2_server: true do
       Object.send(:remove_const, :Item)
     end
   end
-  
+
   def sequel
     connection_string = ENV.fetch('CONNECTION_STRING') {
       raise 'You must define the CONNECTION_STRING environment variable and point it to a valid DB2 for IBM i database'
@@ -30,12 +30,10 @@ describe 'a limit query', needs_live_db2_server: true do
 
   context 'when using a cached dataset' do
     it 'should return an array with the correct number of elements' do
-      sequel do |db|
-        # Sequel starts caching dataset query placeholder arguments on 3rd use
-        3.times { Items.create(name: 'N') }
-        some_items = Items.where(name: 'N')
-        3.times { expect(some_items.first(2).size).to eq(2) }
-      end
+      # Sequel starts caching dataset query placeholder arguments on 3rd use
+      3.times { Items.create(name: 'N') }
+      some_items = Items.where(name: 'N')
+      3.times { expect(some_items.first(2).size).to eq(2) }
     end
   end
 end

--- a/spec/integration/limit_spec.rb
+++ b/spec/integration/limit_spec.rb
@@ -1,0 +1,41 @@
+describe 'a limit query', needs_live_db2_server: true do
+  before do
+    sequel do |db|
+      db.create_table!(:items) do
+        primary_key :id
+        String :name
+      end
+      class ::Item < Sequel::Model(db)
+      end
+    end
+  end
+
+  after do
+    sequel do |db|
+      db.drop_table?(:items)
+      Object.send(:remove_const, :Item)
+    end
+  end
+  
+  def sequel
+    connection_string = ENV.fetch('CONNECTION_STRING') {
+      raise 'You must define the CONNECTION_STRING environment variable and point it to a valid DB2 for IBM i database'
+    }
+    conn = Sequel.connect(connection_string)
+
+    yield conn
+  ensure
+    conn && conn.disconnect
+  end
+
+  context 'when using a cached dataset' do
+    it 'should return an array with the correct number of elements' do
+      sequel do |db|
+        # Sequel starts caching dataset query placeholder arguments on 3rd use
+        3.times { Items.create(name: 'N') }
+        some_items = Items.where(name: 'N')
+        3.times { expect(some_items.first(2).size).to eq(2) }
+      end
+    end
+  end
+end

--- a/spec/integration/limit_spec.rb
+++ b/spec/integration/limit_spec.rb
@@ -1,22 +1,4 @@
 describe 'a limit query', needs_live_db2_server: true do
-  before do
-    sequel do |db|
-      db.create_table!(:items) do
-        primary_key :id
-        String :name
-      end
-      class Item < Sequel::Model(db)
-      end
-    end
-  end
-
-  after do
-    sequel do |db|
-      db.drop_table?(:items)
-      Object.send(:remove_const, :Item)
-    end
-  end
-
   def sequel
     connection_string = ENV.fetch('CONNECTION_STRING') {
       raise 'You must define the CONNECTION_STRING environment variable and point it to a valid DB2 for IBM i database'
@@ -31,9 +13,9 @@ describe 'a limit query', needs_live_db2_server: true do
   context 'when using a cached dataset' do
     it 'should return an array with the correct number of elements' do
       # Sequel starts caching dataset query placeholder arguments on 3rd use
-      3.times { Item.create(name: 'N') }
-      some_items = Item.where(name: 'N')
-      3.times { expect(some_items.first(2).size).to eq(2) }
+      sequel do |db|
+        3.times { expect(db[:MITMAS].first(5).size).to eq(5) }
+      end
     end
   end
 end


### PR DESCRIPTION
On the third execution Sequel will cache the value for limit(), last(), first() etc as a Sequel::Dataset::PlaceholderLiteralizer instead of an integer, causing existing code to fail on line 86 with 'undefined method > for Sequel::Dataset::PlaceholderLiteralizer.'

For example: 
`3.times { Model.last(5) }`

Will fail with that error. This change does lose out on one thing, which is that Model.first(1) will generate SQL like "FETCH FIRST 1 ROWS ONLY" instead of "FETCH FIRST ROW ONLY," but that is still valid syntax.